### PR TITLE
Add links to snapshot and governance forum

### DIFF
--- a/src/components/Footer/components/Nav.tsx
+++ b/src/components/Footer/components/Nav.tsx
@@ -7,6 +7,8 @@ const Nav: React.FC = () => {
       <StyledLink href="https://discord.gg/nKKhBbk">Discord</StyledLink>
       <StyledLink href="https://github.com/yam-finance/yam-www">Github</StyledLink>
       <StyledLink href="https://twitter.com/YamFinance">Twitter</StyledLink>
+      <StyledLink href="https://snapshot.page/#/yam">Proposals</StyledLink>
+      <StyledLink href="https://forum.yam.finance">Forum</StyledLink>
     </StyledNav>
   )
 }


### PR DESCRIPTION
Based on the discussion from https://forum.yam.finance/t/add-snapshot-and-governance-forum-link-to-homepage/457

**Motivation**

We need to encourage people to join the governance. Not all the token holders are aware of these websites and addresses, it is strange that the homepage is not showing a link that can conveniently link anyone who wants to participate governance to the right place.