### PR TITLE
Delegate actions PR

### DIFF
--- a/src/contexts/Governance/Context.ts
+++ b/src/contexts/Governance/Context.ts
@@ -3,11 +3,12 @@ import { createContext } from "react";
 import { ContextValues } from "./types";
 
 const Context = createContext<ContextValues>({
+  isDelegated: false,
   onVote: () => {},
   onRegister: () => {},
   onDelegateStaked: () => {},
   onDelegateUnstaked: () => {},
-  onRemoveDelegation: () => {}
+  onRemoveDelegation: () => {},
 });
 
 export default Context;

--- a/src/contexts/Governance/Context.ts
+++ b/src/contexts/Governance/Context.ts
@@ -7,7 +7,7 @@ const Context = createContext<ContextValues>({
   onRegister: () => {},
   onDelegateStaked: () => {},
   onDelegateUnstaked: () => {},
-  onUndelegate: () => {}
+  onRemoveDelegation: () => {}
 });
 
 export default Context;

--- a/src/contexts/Governance/Context.ts
+++ b/src/contexts/Governance/Context.ts
@@ -5,6 +5,9 @@ import { ContextValues } from "./types";
 const Context = createContext<ContextValues>({
   onVote: () => {},
   onRegister: () => {},
+  onDelegateStaked: () => {},
+  onDelegateUnstaked: () => {},
+  onUndelegate: () => {}
 });
 
 export default Context;

--- a/src/contexts/Governance/Provider.tsx
+++ b/src/contexts/Governance/Provider.tsx
@@ -4,7 +4,16 @@ import BigNumber from "bignumber.js";
 import { useWallet } from "use-wallet";
 
 import useYam from "hooks/useYam";
-import { getProposals, vote, didDelegate, getVotingPowers, getCurrentVotingPower, delegate } from "yam-sdk/utils";
+import {
+  getProposals,
+  vote,
+  didDelegate,
+  getVotingPowers,
+  getCurrentVotingPower,
+  delegate,
+  delegateStaked,
+  delegateUnstaked
+} from "yam-sdk/utils";
 
 import Context from "./Context";
 
@@ -79,6 +88,28 @@ const Provider: React.FC = ({ children }) => {
     setIsRegistering(false);
   }, [account, setIsRegistering, yam]);
 
+  const handleDelegateStaked = useCallback(
+    async (delegatee : string) => {
+      if (!account || !yam) return;
+      await delegateStaked(yam, account, delegatee, (txHash: string) => null);
+    },
+    [account, yam]
+  );
+
+  const handleDelegateUnstaked = useCallback(
+    async (delegatee : string) => {
+      if (!account || !yam) return;
+      await delegateUnstaked(yam, account, delegatee, (txHash: string) => null);
+    },
+    [account, yam]
+  );
+
+  // TODO are two functions necessary?
+  const handleRemoveDelegation = useCallback(async () => {
+    if (!account || !yam) return;
+    await delegate(yam, account, (txHash: string) => null);
+  }, [account, yam]);
+
   useEffect(() => {
     if (yam) {
       fetchProposals();
@@ -104,6 +135,9 @@ const Provider: React.FC = ({ children }) => {
         isVoting,
         onRegister: handleRegisterClick,
         onVote: handleVote,
+        onDelegateStaked: handleDelegateStaked,
+        onDelegateUnstaked: handleDelegateUnstaked,
+        onUndelegate: handleRemoveDelegation
       }}
     >
       {children}

--- a/src/contexts/Governance/Provider.tsx
+++ b/src/contexts/Governance/Provider.tsx
@@ -137,7 +137,7 @@ const Provider: React.FC = ({ children }) => {
         onVote: handleVote,
         onDelegateStaked: handleDelegateStaked,
         onDelegateUnstaked: handleDelegateUnstaked,
-        onUndelegate: handleRemoveDelegation
+        onRemoveDelegation: handleRemoveDelegation
       }}
     >
       {children}

--- a/src/contexts/Governance/Provider.tsx
+++ b/src/contexts/Governance/Provider.tsx
@@ -7,11 +7,11 @@ import useYam from "hooks/useYam";
 import {
   getProposals,
   vote,
-  didDelegate,
   getVotingPowers,
   getCurrentVotingPower,
   delegate,
   delegateStaked,
+  delegatedTo,
 } from "yam-sdk/utils";
 
 import Context from "./Context";
@@ -74,8 +74,7 @@ const Provider: React.FC = ({ children }) => {
 
   const fetchIsRegistered = useCallback(async () => {
     if (!account || !yam) return;
-    const registered = await didDelegate(yam, account);
-    setIsRegistered(registered);
+    setIsRegistered((await delegatedTo(yam, account)) === account);
   }, [account, setIsRegistered, yam]);
 
   useEffect(() => {
@@ -129,7 +128,11 @@ const Provider: React.FC = ({ children }) => {
     }, [account, yam]
   );
 
-  const verifyDelegation = async () => setIsDelegated(await didDelegate(yam, account));
+  const verifyDelegation = async () => {
+    const emptyDelegation = '0x0000000000000000000000000000000000000000';
+    const delegatedAccount = await delegatedTo(yam, account);
+    setIsDelegated(delegatedAccount !== emptyDelegation && delegatedAccount !== account);
+  }
 
   useEffect(
     () => {

--- a/src/contexts/Governance/Provider.tsx
+++ b/src/contexts/Governance/Provider.tsx
@@ -12,7 +12,6 @@ import {
   getCurrentVotingPower,
   delegate,
   delegateStaked,
-  delegateUnstaked
 } from "yam-sdk/utils";
 
 import Context from "./Context";
@@ -84,31 +83,47 @@ const Provider: React.FC = ({ children }) => {
 
   const handleRegisterClick = useCallback(async () => {
     if (!account || !yam) return;
-    await delegate(yam, account, (txHash: string) => setIsRegistering(true));
+    await delegate(yam, account, account, (txHash: string) => setIsRegistering(true));
     setIsRegistering(false);
   }, [account, setIsRegistering, yam]);
 
-  const handleDelegateStaked = useCallback(
-    async (delegatee : string) => {
-      if (!account || !yam) return;
-      await delegateStaked(yam, account, delegatee, (txHash: string) => null);
-    },
-    [account, yam]
-  );
-
   const handleDelegateUnstaked = useCallback(
-    async (delegatee : string) => {
+    async (delegatee: string) => {
       if (!account || !yam) return;
-      await delegateUnstaked(yam, account, delegatee, (txHash: string) => null);
+      try {
+        await delegate(yam, account, delegatee, (txHash: string) => null);
+      }
+      catch(err) {
+        console.error(err.message);
+      }
     },
     [account, yam]
   );
 
-  // TODO are two functions necessary?
-  const handleRemoveDelegation = useCallback(async () => {
-    if (!account || !yam) return;
-    await delegate(yam, account, (txHash: string) => null);
-  }, [account, yam]);
+  const handleDelegateStaked = useCallback(
+    async (delegatee: string) => {
+      if (!account || !yam) return;
+      try {
+        await delegateStaked(yam, account, delegatee, (txHash: string) => null);
+      }
+      catch(err) {
+        console.error(err.message);
+      }
+    },
+    [account, yam]
+  );
+  
+  const handleRemoveDelegation = useCallback(
+    async () => {
+      if (!account || !yam) return;
+      try {
+        await delegate(yam, account, account, (txHash: string) => null);
+      }
+      catch(err) {
+        console.error(err.message);
+      }
+    }, [account, yam]
+  );
 
   useEffect(() => {
     if (yam) {

--- a/src/contexts/Governance/Provider.tsx
+++ b/src/contexts/Governance/Provider.tsx
@@ -92,9 +92,8 @@ const Provider: React.FC = ({ children }) => {
     async (delegatee: string) => {
       if (!account || !yam) return;
       try {
-        await delegate(yam, account, delegatee, (txHash: string) => {
-          if(txHash !== "") setIsDelegated(true);
-        });
+        await delegate(yam, account, delegatee, (txHash: string) => null);
+        verifyDelegation();
       }
       catch(err) {
         console.error(err.message);
@@ -107,9 +106,8 @@ const Provider: React.FC = ({ children }) => {
     async (delegatee: string) => {
       if (!account || !yam) return;
       try {
-        await delegateStaked(yam, account, delegatee, (txHash: string) => {
-          if(txHash !== "") setIsDelegated(true);
-        });
+        await delegateStaked(yam, account, delegatee, (txHash: string) => null)
+        verifyDelegation();
       }
       catch(err) {
         console.error(err.message);
@@ -122,9 +120,8 @@ const Provider: React.FC = ({ children }) => {
     async () => {
       if (!account || !yam) return;
       try {
-        await delegate(yam, account, account, (txHash: string) => {
-          if(txHash !== "") setIsDelegated(false);
-        });
+        await delegate(yam, account, account, (txHash: string) => null);
+        verifyDelegation();
       }
       catch(err) {
         console.error(err.message);
@@ -132,11 +129,11 @@ const Provider: React.FC = ({ children }) => {
     }, [account, yam]
   );
 
+  const verifyDelegation = async () => setIsDelegated(await didDelegate(yam, account));
+
   useEffect(
     () => {
-      if (yam) {
-        (async () => setIsDelegated(await didDelegate(yam, account)))();
-      }
+      if(yam) verifyDelegation();
     },
     [account, yam]
   );

--- a/src/contexts/Governance/types.ts
+++ b/src/contexts/Governance/types.ts
@@ -32,4 +32,7 @@ export interface ContextValues {
   isVoting?: boolean;
   onVote: (proposal: number, side: boolean) => void;
   onRegister: () => void;
+  onDelegateStaked: (delegatee: string) => void;
+  onDelegateUnstaked: (delegatee: string) => void;
+  onUndelegate: () => void;
 }

--- a/src/contexts/Governance/types.ts
+++ b/src/contexts/Governance/types.ts
@@ -30,6 +30,7 @@ export interface ContextValues {
   isRegistered?: boolean;
   isRegistering?: boolean;
   isVoting?: boolean;
+  isDelegated: boolean;
   onVote: (proposal: number, side: boolean) => void;
   onRegister: () => void;
   onDelegateStaked: (delegatee: string) => void;

--- a/src/contexts/Governance/types.ts
+++ b/src/contexts/Governance/types.ts
@@ -34,5 +34,5 @@ export interface ContextValues {
   onRegister: () => void;
   onDelegateStaked: (delegatee: string) => void;
   onDelegateUnstaked: (delegatee: string) => void;
-  onUndelegate: () => void;
+  onRemoveDelegation: () => void;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -33,7 +33,8 @@ a:hover {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }
-button {
+
+button, input {
   font-family: "Nunito";
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import { ethers } from "ethers";
 import Web3 from "web3";
 import { provider, TransactionReceipt } from "web3-core";
-import { AbiItem } from "web3-utils";
+import { AbiItem, isAddress } from "web3-utils";
 
 import ERC20ABI from "constants/abi/ERC20.json";
 
@@ -112,3 +112,5 @@ export const getTimestampDate = (obj: { ts: number; ap?: boolean }) => {
   const year = d.getFullYear().toString().substring(0, 2) + (obj.ap ? " " + getAMPM(d) : "");
   return (day < 9 ? "0" + day : day) + s + (month <= 9 ? "0" + month : month) + s + year;
 };
+
+export const validateAddress = (address: string) => isAddress(address);

--- a/src/views/Addresses/Addresses.tsx
+++ b/src/views/Addresses/Addresses.tsx
@@ -47,7 +47,7 @@ const Addresses: React.FC = () => {
         <AddressButton name="Incentivizer" address={ContractIncentivizer} uniswap={false} />
         <AddressButton name="Migrator" address={ContractMigrator} uniswap={false} />
         <AddressButton name="Contributor Governor" address={ContractContributorGovernor} uniswap={false} />
-        <AddressButton name="Contribtor Timelock" address={ContractContribtorTimelock} uniswap={false} />
+        <AddressButton name="Contributor Timelock" address={ContractContribtorTimelock} uniswap={false} />
         <AddressButton name="Index Staking" address={ContractIndexStaking} uniswap={false} />
         <AddressButton name="Vesting Pool" address={ContractVestingPool} uniswap={false} />
         <AddressButton name="Monthly Allowance" address={ContractMonthlyAllowance} uniswap={false} />

--- a/src/views/Governance/Governance.tsx
+++ b/src/views/Governance/Governance.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback, useMemo, useState } from "react";
-import { Container, Spacer, Card, CardTitle, CardContent, Separator, Surface, Button } from "react-neu";
+import { Container, Spacer, Card, CardTitle, CardContent, Separator, Surface, Button, Input } from "react-neu";
 
 import Page from "components/Page";
 import PageHeader from "components/PageHeader";
@@ -9,8 +9,10 @@ import RegisterVoteNotice from "../Home/components/RegisterVoteNotice";
 import SeparatorGrid from "./components/SeparatorWithCSS";
 import Box from "./components/BoxWithDisplay";
 import styled from "styled-components";
+import DelegateForm from "./components/DelegateForm";
 
 import useGovernance from "hooks/useGovernance";
+import useFarming from "hooks/useFarming";
 import { useWallet } from "use-wallet";
 
 import { ProposalEntry, StyledDescription, StyledState, StyledButton, StyledProposalContentInner } from "./components/Proposal";
@@ -18,7 +20,18 @@ import { ProposalEntry, StyledDescription, StyledState, StyledButton, StyledProp
 const ASTRONAUTS = ["👨‍🚀", "👨🏻‍🚀", "👨🏼‍🚀", "👨🏽‍🚀", "👨🏾‍🚀", "👩‍🚀", "👩🏻‍🚀", "👩🏼‍🚀", "👩🏽‍🚀", "👩🏾‍🚀‍", "👩🏿‍🚀"];
 
 const Governance: React.FC = () => {
-  const { proposals, isRegistered, onVote, onRegister } = useGovernance();
+  const {
+    proposals,
+    isRegistered,
+    onVote,
+    onRegister,
+    onDelegateStaked,
+    onDelegateUnstaked,
+    onUndelegate
+  } = useGovernance();
+
+  const { stakedBalanceYAMETH } = useFarming();
+  const isStaked = !!stakedBalanceYAMETH && stakedBalanceYAMETH.toNumber() > 0;
 
   const [astronaut, setAstronaut] = useState("👨‍🚀");
 
@@ -46,7 +59,20 @@ const Governance: React.FC = () => {
           <Button full text="Off-chain Voting" href="https://snapshot.page/#/yam" variant="tertiary" />
           <Spacer />
         </Split>
-        <Spacer size="lg" />
+        <Spacer size="md" />
+        <Card>
+          <CardTitle text="Delegate Vote" />
+          <CardContent>
+            <Box display="grid" alignItems="center" paddingLeft={4} paddingRight={4} paddingBottom={1} row>
+              <DelegateForm
+                isStaked={isStaked}
+                onDelegateStaked={onDelegateStaked}
+                onDelegateUnstaked={onDelegateUnstaked}
+                onUndelegate={onUndelegate} />
+            </Box>
+          </CardContent>
+        </Card>
+        <Spacer size="md" />
         <Card>
           <CardTitle text="On-chain Proposals" />
           <Spacer size="sm" />

--- a/src/views/Governance/Governance.tsx
+++ b/src/views/Governance/Governance.tsx
@@ -20,6 +20,7 @@ import { ProposalEntry, StyledDescription, StyledState, StyledButton, StyledProp
 const ASTRONAUTS = ["👨‍🚀", "👨🏻‍🚀", "👨🏼‍🚀", "👨🏽‍🚀", "👨🏾‍🚀", "👩‍🚀", "👩🏻‍🚀", "👩🏼‍🚀", "👩🏽‍🚀", "👩🏾‍🚀‍", "👩🏿‍🚀"];
 
 const Governance: React.FC = () => {
+  const { account } = useWallet();
   const {
     proposals,
     isRegistered,
@@ -27,9 +28,8 @@ const Governance: React.FC = () => {
     onRegister,
     onDelegateStaked,
     onDelegateUnstaked,
-    onUndelegate
+    onRemoveDelegation,
   } = useGovernance();
-
   const { stakedBalanceYAMETH } = useFarming();
   const isStaked = !!stakedBalanceYAMETH && stakedBalanceYAMETH.toNumber() > 0;
 
@@ -60,18 +60,20 @@ const Governance: React.FC = () => {
           <Spacer />
         </Split>
         <Spacer size="md" />
-        <Card>
-          <CardTitle text="Delegate Vote" />
-          <CardContent>
-            <Box display="grid" alignItems="center" paddingLeft={4} paddingRight={4} paddingBottom={1} row>
-              <DelegateForm
-                isStaked={isStaked}
-                onDelegateStaked={onDelegateStaked}
-                onDelegateUnstaked={onDelegateUnstaked}
-                onUndelegate={onUndelegate} />
-            </Box>
-          </CardContent>
-        </Card>
+        {account && (
+          <Card>
+            <CardTitle text="Delegate Vote" />
+            <CardContent>
+              <Box display="grid" alignItems="center" paddingLeft={4} paddingRight={4} paddingBottom={1} row>
+                <DelegateForm
+                  isStaked={isStaked}
+                  onDelegateStaked={onDelegateStaked}
+                  onDelegateUnstaked={onDelegateUnstaked}
+                  onRemoveDelegation={onRemoveDelegation} />
+              </Box>
+            </CardContent>
+          </Card>
+        )}
         <Spacer size="md" />
         <Card>
           <CardTitle text="On-chain Proposals" />

--- a/src/views/Governance/Governance.tsx
+++ b/src/views/Governance/Governance.tsx
@@ -24,6 +24,7 @@ const Governance: React.FC = () => {
   const {
     proposals,
     isRegistered,
+    isDelegated,
     onVote,
     onRegister,
     onDelegateStaked,
@@ -31,8 +32,8 @@ const Governance: React.FC = () => {
     onRemoveDelegation,
   } = useGovernance();
   const { stakedBalanceYAMETH } = useFarming();
-  const isStaked = !!stakedBalanceYAMETH && stakedBalanceYAMETH.toNumber() > 0;
 
+  const isStaked = !!stakedBalanceYAMETH && stakedBalanceYAMETH.toNumber() > 0;
   const [astronaut, setAstronaut] = useState("👨‍🚀");
 
   const updateAstronaut = useCallback(() => {
@@ -67,9 +68,11 @@ const Governance: React.FC = () => {
               <Box display="grid" alignItems="center" paddingLeft={4} paddingRight={4} paddingBottom={1} row>
                 <DelegateForm
                   isStaked={isStaked}
+                  isDelegated={isDelegated}
                   onDelegateStaked={onDelegateStaked}
                   onDelegateUnstaked={onDelegateUnstaked}
-                  onRemoveDelegation={onRemoveDelegation} />
+                  onRemoveDelegation={onRemoveDelegation}
+                />
               </Box>
             </CardContent>
           </Card>

--- a/src/views/Governance/components/DelegateForm.tsx
+++ b/src/views/Governance/components/DelegateForm.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, useState, useCallback } from 'react';
-import { Container, Spacer, Card, CardTitle, CardContent, Separator, Surface, Button, Input } from "react-neu";
+import { Spacer, Button, Input } from "react-neu";
 import Split from "components/Split";
 import { validateAddress } from 'utils';
 
@@ -10,7 +10,12 @@ interface DelegateFormProps {
   onRemoveDelegation: () => void
 }
 
-const DelegateForm: React.FC<DelegateFormProps> = ({ isStaked, onDelegateStaked, onDelegateUnstaked, onRemoveDelegation }) => {
+const DelegateForm: React.FC<DelegateFormProps> = ({
+  isStaked,
+  onDelegateStaked,
+  onDelegateUnstaked,
+  onRemoveDelegation
+}) => {
   const [delegatee, setDelegatee] = useState('');
 
   const handleOnDelegateStaked = useCallback(
@@ -32,14 +37,19 @@ const DelegateForm: React.FC<DelegateFormProps> = ({ isStaked, onDelegateStaked,
 
   return (
     <Fragment>
-      <Input onChange={onChange} placeholder=" Delegate to..."></Input>
+      <Input onChange={onChange} placeholder="Delegate to..."></Input>
       <Spacer />
       <Split>
-        <Button full text="Delegate" variant="tertiary" onClick={isStaked ? handleOnDelegateStaked : handleOnDelegateUnstaked} disabled={!validateAddress(delegatee)} />
+        <Button full
+          text="Delegate"
+          variant="tertiary" 
+          onClick={isStaked ? handleOnDelegateStaked : handleOnDelegateUnstaked}
+          disabled={!validateAddress(delegatee)}
+        />
         <Button full text="Remove Delegation" variant="tertiary" onClick={handleOnRemoveDelegation} />
       </Split>
     </Fragment>
-  )
-}
+  );
+};
 
 export default DelegateForm;

--- a/src/views/Governance/components/DelegateForm.tsx
+++ b/src/views/Governance/components/DelegateForm.tsx
@@ -1,40 +1,42 @@
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, useState, useCallback } from 'react';
 import { Container, Spacer, Card, CardTitle, CardContent, Separator, Surface, Button, Input } from "react-neu";
 import Split from "components/Split";
+import { validateAddress } from 'utils';
 
 interface DelegateFormProps {
   isStaked: boolean,
   onDelegateUnstaked: (delegatee: string) => void,
   onDelegateStaked: (delegatee: string) => void,
-  onUndelegate: () => void
+  onRemoveDelegation: () => void
 }
 
-const DelegateForm: React.FC<DelegateFormProps> = ({ isStaked, onDelegateStaked, onDelegateUnstaked, onUndelegate }) => {
+const DelegateForm: React.FC<DelegateFormProps> = ({ isStaked, onDelegateStaked, onDelegateUnstaked, onRemoveDelegation }) => {
   const [delegatee, setDelegatee] = useState('');
 
-  const delegateStaked = () => {
-    console.log('delegate staked called!!')
-    onDelegateStaked(delegatee);
-  }
+  const handleOnDelegateStaked = useCallback(
+    () => onDelegateStaked(delegatee),
+    [onDelegateStaked, delegatee]
+  );
 
-  const delegateUnstaked = () => {
-    console.log('delegate unstaked called!!')
-    onDelegateUnstaked(delegatee);
-  }
+  const handleOnDelegateUnstaked = useCallback(
+    () => onDelegateUnstaked(delegatee),
+    [onDelegateUnstaked, delegatee]
+  );
 
-  const undelegate = () => {
-    console.log('undelegate called!!')
-  }
+  const handleOnRemoveDelegation = useCallback(
+    () => onRemoveDelegation(),
+    [onRemoveDelegation]
+  );
 
-  const onChange = (e: any) => setDelegatee(e.target.value);
+  const onChange = (e: any): void => setDelegatee(e.target.value);
 
   return (
     <Fragment>
-      <Input onChange={onChange} placeholder="Delegate to..."></Input>
+      <Input onChange={onChange} placeholder=" Delegate to..."></Input>
       <Spacer />
       <Split>
-        <Button full text="Delegate" variant="tertiary" onClick={isStaked ? delegateStaked : delegateUnstaked} />
-        <Button full text="Remove Delegation" variant="tertiary" onClick={undelegate} />
+        <Button full text="Delegate" variant="tertiary" onClick={isStaked ? handleOnDelegateStaked : handleOnDelegateUnstaked} disabled={!validateAddress(delegatee)} />
+        <Button full text="Remove Delegation" variant="tertiary" onClick={handleOnRemoveDelegation} />
       </Split>
     </Fragment>
   )

--- a/src/views/Governance/components/DelegateForm.tsx
+++ b/src/views/Governance/components/DelegateForm.tsx
@@ -41,14 +41,14 @@ export const DelegateForm: React.FC<DelegateFormProps> = ({
         <Button
           full
           text="Delegate"
-          variant="tertiary" 
+          variant="secondary"
           onClick={isStaked ? handleOnDelegateStaked : handleOnDelegateUnstaked}
           disabled={!validateAddress(delegatee)}
         />
         <Button
           full
           text="Remove Delegation"
-          variant="tertiary"
+          variant="secondary"
           onClick={onRemoveDelegation}
           disabled={!isDelegated}/>
       </Split>

--- a/src/views/Governance/components/DelegateForm.tsx
+++ b/src/views/Governance/components/DelegateForm.tsx
@@ -28,11 +28,6 @@ const DelegateForm: React.FC<DelegateFormProps> = ({
     [onDelegateUnstaked, delegatee]
   );
 
-  const handleOnRemoveDelegation = useCallback(
-    () => onRemoveDelegation(),
-    [onRemoveDelegation]
-  );
-
   const onChange = (e: any): void => setDelegatee(e.target.value);
 
   return (
@@ -46,7 +41,7 @@ const DelegateForm: React.FC<DelegateFormProps> = ({
           onClick={isStaked ? handleOnDelegateStaked : handleOnDelegateUnstaked}
           disabled={!validateAddress(delegatee)}
         />
-        <Button full text="Remove Delegation" variant="tertiary" onClick={handleOnRemoveDelegation} />
+        <Button full text="Remove Delegation" variant="tertiary" onClick={onRemoveDelegation} />
       </Split>
     </Fragment>
   );

--- a/src/views/Governance/components/DelegateForm.tsx
+++ b/src/views/Governance/components/DelegateForm.tsx
@@ -1,0 +1,43 @@
+import React, { Fragment, useState } from 'react';
+import { Container, Spacer, Card, CardTitle, CardContent, Separator, Surface, Button, Input } from "react-neu";
+import Split from "components/Split";
+
+interface DelegateFormProps {
+  isStaked: boolean,
+  onDelegateUnstaked: (delegatee: string) => void,
+  onDelegateStaked: (delegatee: string) => void,
+  onUndelegate: () => void
+}
+
+const DelegateForm: React.FC<DelegateFormProps> = ({ isStaked, onDelegateStaked, onDelegateUnstaked, onUndelegate }) => {
+  const [delegatee, setDelegatee] = useState('');
+
+  const delegateStaked = () => {
+    console.log('delegate staked called!!')
+    onDelegateStaked(delegatee);
+  }
+
+  const delegateUnstaked = () => {
+    console.log('delegate unstaked called!!')
+    onDelegateUnstaked(delegatee);
+  }
+
+  const undelegate = () => {
+    console.log('undelegate called!!')
+  }
+
+  const onChange = (e: any) => setDelegatee(e.target.value);
+
+  return (
+    <Fragment>
+      <Input onChange={onChange} placeholder="Delegate to..."></Input>
+      <Spacer />
+      <Split>
+        <Button full text="Delegate" variant="tertiary" onClick={isStaked ? delegateStaked : delegateUnstaked} />
+        <Button full text="Remove Delegation" variant="tertiary" onClick={undelegate} />
+      </Split>
+    </Fragment>
+  )
+}
+
+export default DelegateForm;

--- a/src/views/Governance/components/DelegateForm.tsx
+++ b/src/views/Governance/components/DelegateForm.tsx
@@ -1,17 +1,20 @@
-import React, { Fragment, useState, useCallback } from 'react';
+import React, { Fragment, useState, useCallback, useEffect } from 'react';
 import { Spacer, Button, Input } from "react-neu";
 import Split from "components/Split";
 import { validateAddress } from 'utils';
+import styled from "styled-components";
 
 interface DelegateFormProps {
   isStaked: boolean,
+  isDelegated: boolean,
   onDelegateUnstaked: (delegatee: string) => void,
   onDelegateStaked: (delegatee: string) => void,
-  onRemoveDelegation: () => void
+  onRemoveDelegation: () => void,
 }
 
-const DelegateForm: React.FC<DelegateFormProps> = ({
+export const DelegateForm: React.FC<DelegateFormProps> = ({
   isStaked,
+  isDelegated,
   onDelegateStaked,
   onDelegateUnstaked,
   onRemoveDelegation
@@ -35,13 +38,19 @@ const DelegateForm: React.FC<DelegateFormProps> = ({
       <Input onChange={onChange} placeholder="Delegate to..."></Input>
       <Spacer />
       <Split>
-        <Button full
+        <Button
+          full
           text="Delegate"
           variant="tertiary" 
           onClick={isStaked ? handleOnDelegateStaked : handleOnDelegateUnstaked}
           disabled={!validateAddress(delegatee)}
         />
-        <Button full text="Remove Delegation" variant="tertiary" onClick={onRemoveDelegation} />
+        <Button
+          full
+          text="Remove Delegation"
+          variant="tertiary"
+          onClick={onRemoveDelegation}
+          disabled={!isDelegated}/>
       </Split>
     </Fragment>
   );

--- a/src/views/Governance/components/VoteModal.tsx
+++ b/src/views/Governance/components/VoteModal.tsx
@@ -10,7 +10,6 @@ import styled from "styled-components";
 import useYam from "hooks/useYam";
 import useGovernance from "hooks/useGovernance";
 import { useWallet } from "use-wallet";
-import { delegate, didDelegate } from "yam-sdk/utils";
 
 import { Proposal } from "../../../contexts/Governance/types";
 import Split from "components/Split";

--- a/src/views/Home/components/RegisterVoteNotice.tsx
+++ b/src/views/Home/components/RegisterVoteNotice.tsx
@@ -21,7 +21,7 @@ const RegisterVoteNotice: React.FC = () => {
 
   const handleRegisterClick = useCallback(async () => {
     if (!account || !yam) return;
-    await delegate(yam, account, (txHash: string) => setIsRegistering(!!txHash));
+    await delegate(yam, account, account, (txHash: string) => setIsRegistering(!!txHash));
     setIsRegistering(false);
   }, [account, setIsRegistering, yam]);
 

--- a/src/views/Home/components/RegisterVoteNotice.tsx
+++ b/src/views/Home/components/RegisterVoteNotice.tsx
@@ -5,7 +5,7 @@ import styled from "styled-components";
 import { useWallet } from "use-wallet";
 
 import useYam from "hooks/useYam";
-import { delegate, didDelegate } from "yam-sdk/utils";
+import { delegate, delegatedTo } from "yam-sdk/utils";
 
 const RegisterVoteNotice: React.FC = () => {
   const [isRegistered, setIsRegistered] = useState<boolean>();
@@ -15,8 +15,7 @@ const RegisterVoteNotice: React.FC = () => {
 
   const fetchIsRegistered = useCallback(async () => {
     if (!account || !yam) return;
-    const registered = await didDelegate(yam, account);
-    setIsRegistered(registered);
+    setIsRegistered((await delegatedTo(yam, account)) === account);
   }, [account, setIsRegistered, yam]);
 
   const handleRegisterClick = useCallback(async () => {

--- a/src/yam-sdk/utils/index.js
+++ b/src/yam-sdk/utils/index.js
@@ -271,60 +271,38 @@ export const getStats = async (yam) => {
   };
 };
 
-export const delegate = async (yam, account, onTxHash) => {
-  console.log('REMOVE DELEGATION CALLED')
-//return yam.contracts.yamV3.methods.delegate(account).send({ from: account, gas: 150000 }, async (error, txHash) => {
-//  if (error) {
-//    onTxHash && onTxHash("");
-//    console.log("Delegate error", error);
-//    return false;
-//  }
-//  onTxHash && onTxHash(txHash);
-//  const status = await waitTransaction(yam.web3.eth, txHash);
-//  if (!status) {
-//    console.log("Delegate transaction failed.");
-//    return false;
-//  }
-//  return true;
-//});
-};
-
-export const delegateUnstaked = async (yam, account, delegatee, onTxHash) => {
-  console.log(`DELEGATEE IS ${delegatee}`);
-  console.log('DELEGATE UNSTAKED CALLED')
-//return yam.contracts.yamV3.methods.delegate(delegatee).send({ from: account, gas: 150000 }, async (error, txHash) => {
-//  if (error) {
-//    onTxHash && onTxHash("");
-//    console.log("Delegate error", error);
-//    return false;
-//  }
-//  onTxHash && onTxHash(txHash);
-//  const status = await waitTransaction(yam.web3.eth, txHash);
-//  if (!status) {
-//    console.log("Delegate transaction failed.");
-//    return false;
-//  }
-//  return true;
-//});
+export const delegate = async (yam, account, delegatee, onTxHash) => {
+  return yam.contracts.yamV3.methods.delegate(delegatee).send({ from: account, gas: 150000 }, async (error, txHash) => {
+    if (error) {
+      onTxHash && onTxHash("");
+      console.log("Delegate error", error);
+      return false;
+    }
+    onTxHash && onTxHash(txHash);
+    const status = await waitTransaction(yam.web3.eth, txHash);
+    if (!status) {
+      console.log("Delegate transaction failed.");
+      return false;
+    }
+    return true;
+  });
 };
 
 export const delegateStaked = async (yam, account, delegatee, onTxHash) => {
-  console.log(`DELEGATEE IS ${delegatee}`);
-  console.log('DELEGATE STAKED CALLED')
-//return yam.contracts.voting_eth_pool.methods.delegate(delegatee).send({ from: account, gas: 150000 }, async (error, txHash) => {
-//  if (error) {
-//    onTxHash && onTxHash("");
-//    console.log("Delegate error", error);
-//    return false;
-//  }
-//  onTxHash && onTxHash(txHash);
-//  const status = await waitTransaction(yam.web3.eth, txHash);
-//  if (!status) {
-//    console.log("Delegate transaction failed.");
-//    return false;
-//  }
-//  return true;
-//});
+  return yam.contracts.voting_eth_pool.methods.delegate(delegatee).send({ from: account, gas: 150000 }, async (error, txHash) => {
+    if (error) {
+      onTxHash && onTxHash("");
+      console.log("Delegate error", error);
+      return false;
+    }
+    onTxHash && onTxHash(txHash);
+    const status = await waitTransaction(yam.web3.eth, txHash);
+    if (!status) {
+      console.log("Delegate transaction failed.");
+      return false;
+    }
+    return true;
+  });
 };
 
 export const didDelegate = async (yam, account) => {

--- a/src/yam-sdk/utils/index.js
+++ b/src/yam-sdk/utils/index.js
@@ -290,6 +290,7 @@ export const delegate = async (yam, account, onTxHash) => {
 };
 
 export const delegateUnstaked = async (yam, account, delegatee, onTxHash) => {
+  console.log(`DELEGATEE IS ${delegatee}`);
   console.log('DELEGATE UNSTAKED CALLED')
 //return yam.contracts.yamV3.methods.delegate(delegatee).send({ from: account, gas: 150000 }, async (error, txHash) => {
 //  if (error) {
@@ -308,6 +309,7 @@ export const delegateUnstaked = async (yam, account, delegatee, onTxHash) => {
 };
 
 export const delegateStaked = async (yam, account, delegatee, onTxHash) => {
+  console.log(`DELEGATEE IS ${delegatee}`);
   console.log('DELEGATE STAKED CALLED')
 //return yam.contracts.voting_eth_pool.methods.delegate(delegatee).send({ from: account, gas: 150000 }, async (error, txHash) => {
 //  if (error) {

--- a/src/yam-sdk/utils/index.js
+++ b/src/yam-sdk/utils/index.js
@@ -306,7 +306,11 @@ export const delegateStaked = async (yam, account, delegatee, onTxHash) => {
 };
 
 export const didDelegate = async (yam, account) => {
-  return (await yam.contracts.yamV3.methods.delegates(account).call()) === account;
+  const [unstaked, staked] = await Promise.allSettled([
+    yam.contracts.yamV3.methods.delegates(account).call(),
+    yam.contracts.voting_eth_pool.methods.delegates(account).call()
+  ]);
+  return unstaked === account || staked === account;
 };
 
 export const vote = async (yam, proposal, side, account, onTxHash) => {

--- a/src/yam-sdk/utils/index.js
+++ b/src/yam-sdk/utils/index.js
@@ -305,13 +305,21 @@ export const delegateStaked = async (yam, account, delegatee, onTxHash) => {
   });
 };
 
-export const didDelegate = async (yam, account) => {
+export const delegatedTo = async(yam, account) => {
+  const emptyDelegation = '0x0000000000000000000000000000000000000000';
   const [unstaked, staked] = await Promise.allSettled([
     yam.contracts.yamV3.methods.delegates(account).call(),
     yam.contracts.voting_eth_pool.methods.delegates(account).call()
   ]);
-  return unstaked === account || staked === account;
-};
+
+  if(unstaked.value !== emptyDelegation) {
+    return unstaked.value
+  } else if(staked.value !== emptyDelegation) {
+    return staked.value
+  } else {
+    return emptyDelegation;
+  }
+}
 
 export const vote = async (yam, proposal, side, account, onTxHash) => {
   return yam.contracts.gov3.methods.castVote(proposal, side).send({ from: account, gas: 180000 }, async (error, txHash) => {

--- a/src/yam-sdk/utils/index.js
+++ b/src/yam-sdk/utils/index.js
@@ -272,20 +272,57 @@ export const getStats = async (yam) => {
 };
 
 export const delegate = async (yam, account, onTxHash) => {
-  return yam.contracts.yamV3.methods.delegate(account).send({ from: account, gas: 150000 }, async (error, txHash) => {
-    if (error) {
-      onTxHash && onTxHash("");
-      console.log("Delegate error", error);
-      return false;
-    }
-    onTxHash && onTxHash(txHash);
-    const status = await waitTransaction(yam.web3.eth, txHash);
-    if (!status) {
-      console.log("Delegate transaction failed.");
-      return false;
-    }
-    return true;
-  });
+  console.log('REMOVE DELEGATION CALLED')
+//return yam.contracts.yamV3.methods.delegate(account).send({ from: account, gas: 150000 }, async (error, txHash) => {
+//  if (error) {
+//    onTxHash && onTxHash("");
+//    console.log("Delegate error", error);
+//    return false;
+//  }
+//  onTxHash && onTxHash(txHash);
+//  const status = await waitTransaction(yam.web3.eth, txHash);
+//  if (!status) {
+//    console.log("Delegate transaction failed.");
+//    return false;
+//  }
+//  return true;
+//});
+};
+
+export const delegateUnstaked = async (yam, account, delegatee, onTxHash) => {
+  console.log('DELEGATE UNSTAKED CALLED')
+//return yam.contracts.yamV3.methods.delegate(delegatee).send({ from: account, gas: 150000 }, async (error, txHash) => {
+//  if (error) {
+//    onTxHash && onTxHash("");
+//    console.log("Delegate error", error);
+//    return false;
+//  }
+//  onTxHash && onTxHash(txHash);
+//  const status = await waitTransaction(yam.web3.eth, txHash);
+//  if (!status) {
+//    console.log("Delegate transaction failed.");
+//    return false;
+//  }
+//  return true;
+//});
+};
+
+export const delegateStaked = async (yam, account, delegatee, onTxHash) => {
+  console.log('DELEGATE STAKED CALLED')
+//return yam.contracts.voting_eth_pool.methods.delegate(delegatee).send({ from: account, gas: 150000 }, async (error, txHash) => {
+//  if (error) {
+//    onTxHash && onTxHash("");
+//    console.log("Delegate error", error);
+//    return false;
+//  }
+//  onTxHash && onTxHash(txHash);
+//  const status = await waitTransaction(yam.web3.eth, txHash);
+//  if (!status) {
+//    console.log("Delegate transaction failed.");
+//    return false;
+//  }
+//  return true;
+//});
 };
 
 export const didDelegate = async (yam, account) => {


### PR DESCRIPTION
Adding the Delegate action as a component on the Governance page as per yam-finance/yam-www#115. This allows an address to delegate their vote to another address. Some assumptions and questions about the app's architecture:

- All Web3 utility functions should come from the utils internal library (src/utils/index.ts), so I made a validateAddress function to wrap Web3's isAddress
- Why does the Button component require a function with no arguments?
    - It seems like if you changed the Button component to take a function with any arguments, you could remove the need for using useCallback for all function props with arguments.

Please let me if there are any issues or questions. Thanks.