### PR TITLE
update emojis on farm, projects, fix project links, pull start cards …

### DIFF
--- a/src/components/DegenerativeCard/DegenerativeCard.tsx
+++ b/src/components/DegenerativeCard/DegenerativeCard.tsx
@@ -19,7 +19,7 @@ const DegenerativeCard: React.FC = () => {
           </Box>
         </CardContent>
         <CardActions>
-          <Button full href="http://synths.yam.xyz" text="View" variant="secondary" />
+          <Button full href="https://synths.yam.finance/" text="Visit" variant="secondary" />
         </CardActions>
         </StyledCard>
     </Card>

--- a/src/components/MofyCard/MofyCard.tsx
+++ b/src/components/MofyCard/MofyCard.tsx
@@ -22,7 +22,7 @@ const MofyCard: React.FC = () => {
         </Box>
       </CardContent>
       <CardActions>
-      <Button full href="https://nft.yam.xyz/" text="View" variant="secondary" />
+      <Button full href="https://www.cryptovoxels.com/play?coords=S@678W,600S" text="Visit" variant="secondary" />
       </CardActions>
       </StyledCard>
     </Card>

--- a/src/components/UmbrellaCard/UmbrellaCard.tsx
+++ b/src/components/UmbrellaCard/UmbrellaCard.tsx
@@ -19,7 +19,7 @@ const UmbrellaCard: React.FC = () => {
           </Box>
         </CardContent>
         <CardActions>
-          <Button full to="/umbrella" text="View" variant="secondary" />
+          <Button full to="/umbrella" text="Info" variant="secondary" />
         </CardActions>
       </StyledCard>
     </Card>

--- a/src/components/YamDaoCard/YamDaoCard.tsx
+++ b/src/components/YamDaoCard/YamDaoCard.tsx
@@ -19,7 +19,7 @@ const YamDaoCard: React.FC = () => {
           </Box>
         </CardContent>
         <CardActions>
-          <Button full href="https://tokensets.com/portfolio/yamhouse" text="View" variant="secondary" />
+          <Button full to="/daohouse" text="Info" variant="secondary" />
         </CardActions>
       </StyledCard>
     </Card>

--- a/src/views/Farm/Farm.tsx
+++ b/src/views/Farm/Farm.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useState, useEffect, useMemo, useRef } from "react";
 
 import { Box, Button, Card, CardContent, Container, Separator, Spacer, useTheme } from "react-neu";
 
 import CountUp, { useCountUp } from 'react-countup';
-
+import { Icon, Pagination } from 'semantic-ui-react';
 import numeral from "numeral";
 import Page from "components/Page";
 import PageHeader from "components/PageHeader";
@@ -17,7 +17,34 @@ import HarvestLPsNoticeYAMYUSD from "./components/HarvestLPsNoticeYAMYUSD";
 import { useWallet } from "use-wallet";
 import FancyValue from "components/FancyValue";
 
+const FARMERS = [
+  '👨‍🌾',
+  '👨🏼‍🌾',
+  '🧑🏽‍🌾',
+  '👨🏻‍🌾',
+  '👨🏿‍🌾',
+  '👩‍🌾',
+  '🧑‍🌾',
+  '👩🏽‍🌾',
+  '👩🏻‍🌾',
+  '🧑🏾‍🌾‍',
+  '👩🏿‍🌾'
+]
+
 const Farm: React.FC = () => {
+
+  const [farmer, setFarmer] = useState('👨‍🌾')
+
+  const updateFarmer = useCallback(() => {
+    const newFarmer = FARMERS[Math.floor(Math.random()*FARMERS.length)]
+    setFarmer(newFarmer)
+  }, [setFarmer])
+
+  useEffect(() => {
+    const refresh = setInterval(updateFarmer, 1000)
+    return () => clearInterval(refresh)
+  }, [updateFarmer])
+
   const { colors } = useTheme();
   const { status } = useWallet();
 
@@ -53,12 +80,13 @@ const Farm: React.FC = () => {
     if (!isRedeeming) {
       return <Button onClick={onRedeemYAMETH} text="Harvest &amp; Unstake YAM/ETH" variant="secondary" />;
     }
+    {/* This code needs to be updated to revert to original state if the transaction is cancelled in metamask */}
     return <Button disabled text="Redeeming..." variant="secondary" />;
   }, [isRedeeming, onRedeemYAMETH]);
 
   return (
     <Page>
-      <PageHeader icon="🌾🍠" subtitle="Stake YAM/ETH Sushiswap LP tokens and grow YAMs" title="Farm" />
+      <PageHeader icon={`${farmer}`} subtitle="Stake YAM/ETH Sushiswap LP tokens and grow YAMs" title="Farm" />
       <Container>
         <HarvestLPsNoticeYAMYUSD />
         <ResumedLPsNotice />

--- a/src/views/Migrate/Migrate.tsx
+++ b/src/views/Migrate/Migrate.tsx
@@ -15,8 +15,10 @@ const Migrate: React.FC = () => {
     <Page>
       <PageHeader icon="🦋" subtitle="This is the last time you'll need to migrate!" title="Migrate to V3" />
       <Container>
-        <EndingMigrationNotice />
+        {/** 
+        * <EndingMigrationNotice/> 
         <Spacer />
+        */}
         <VestingNotice />
         <Spacer />
         <Split>

--- a/src/views/Projects/Projects.tsx
+++ b/src/views/Projects/Projects.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useState, useEffect } from "react";
 import { Container, Spacer } from "react-neu";
 
 import Page from "components/Page";
@@ -9,10 +9,37 @@ import DegenerativeCard from "components/DegenerativeCard"
 import YamDaoCard from "components/YamDaoCard"
 import MofyCard from "components/MofyCard"
 
+const WORKERS = [
+  '👷',
+  '👷‍♂️',
+  '👷🏽',
+  '👷🏻',
+  '👷🏾',
+  '👷🏽‍♀️',
+  '👷🏻‍♀️',
+  '👷🏼‍♀️',
+  '👷🏼‍♀️',
+  '👷🏾‍♀️‍',
+  '👷🏿‍♂️'
+]
+
 const Projects: React.FC = () => {
+
+    const [worker, setWorker] = useState('👷')
+
+  const updateWorker = useCallback(() => {
+    const newWorker = WORKERS[Math.floor(Math.random() * WORKERS.length)]
+    setWorker(newWorker)
+  }, [setWorker])
+
+  useEffect(() => {
+    const refresh = setInterval(updateWorker, 1000)
+    return () => clearInterval(refresh)
+  }, [updateWorker])
+
   return (
     <Page>
-      <PageHeader icon="🏆" subtitle="" title="Projects" />
+      <PageHeader icon={`${worker}`} subtitle="Take a look at what we are working on." title="Projects" />
       <Container size="lg">
         <Spacer />
         <Split>
@@ -25,5 +52,6 @@ const Projects: React.FC = () => {
     </Page>
   );
 };
+
 
 export default Projects;

--- a/src/views/Start/Start.tsx
+++ b/src/views/Start/Start.tsx
@@ -68,10 +68,10 @@ const Start: React.FC = () => {
         </Container>
       </StyledHero>
       <Container size="lg">
-        <Spacer size="lg" />
+        {/*<Spacer size="md" />
         <Separator />
         <Spacer size="lg" />
-        <StyledSectionIcon>⚖️</StyledSectionIcon>
+        <StyledSectionIcon>⚖️</StyledSectionIcon>*/}
         <Spacer size="lg" />
         <StyledSectionTitle>Fair finance for everyone.</StyledSectionTitle>
         <StyledSectionDescription>Yam is owned and controlled by our community of Yam token holders.</StyledSectionDescription>


### PR DESCRIPTION
…above fold

### Description of changes proposed in this pull request:
- This is the 2nd of 3 updates for the website 
- Added new emoji header animations for the Farm and Projects page to match the astronaut animation on the govern page.
- Fixed links on the projects page.
  - yam synths redirects correctly
  - DAOhouse goes to the project card because the set protocol link doesnt exist anymore
  - Mofy redirects to the cryptovoxels museum. We can change this to something else, but it is better than a broken link.
- I changed the start page to remove the scales emoji and limit the space between the hero banner and the cards. Then now sit "above the fold" on the screen and are not cut off like they were. (this may be monitor specific though)
- Removed the migration notice from the v3 migration page.

### Checks:
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of the below if it's not not applicable to your PR -->

### New Feature Submission:
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you lint your code locally prior to submission?

### Changes to Existing Features:
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
